### PR TITLE
Update copy for `pending_status`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
   stop_masquerading: "Stop Masquerading"
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
-  pending_status: "Hound is busy reviewing changes..."
+  pending_status: "Hound is busy sniffing around..."
   cannot_activate_repo: "Only repo admins can activate"
   complete_status:
     zero: "No violations found. Woof!"


### PR DESCRIPTION
This PR is not fixing any bugs and it is not adding any additional features. It is simply updating the copy of one of the Hound status texts to something more canine related.